### PR TITLE
JSON MIME Type

### DIFF
--- a/servedir
+++ b/servedir
@@ -11,7 +11,7 @@ var http = require('http'),
     mimeTypes = {
       html: 'text/html',
       js: 'text/javascript',
-      json: 'text/javascript',
+      json: 'application/json',
       css: 'text/css',
       txt: 'text/plain',
       jpg: 'image/jpeg',


### PR DESCRIPTION
The correct mime type for .json files is application/json (per RFC 4627, http://www.ietf.org/rfc/rfc4627.txt).
