### PR TITLE
fix command line usage with `#!/usr/bin/env node`

### DIFF
--- a/servedir.js
+++ b/servedir.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /*!
  * servedir HTTP Server
  * http://github.com/rem/servedir


### PR DESCRIPTION
Hope this helps. npm + 0.4.0 must have changed things up, this didn't used to be a problem.
Cheers and thanks for servedir!
-David
