### PR TITLE
only serve files internally for better security

### DIFF
--- a/bin/servedir
+++ b/bin/servedir
@@ -27,6 +27,10 @@ fs.realpath(__filename, function(error, script) {
     options.quiet = true;
   });
 
+  controlArg(process.argv, 'external', function () {
+    options.allowExternalAccess = true;
+  });
+
   // Load `servedir`.
   servedir = require(path.join(path.dirname(script), '../lib/servedir'));
 

--- a/lib/servedir.js
+++ b/lib/servedir.js
@@ -110,7 +110,7 @@ var servedir = module.exports = function(root, port, options) {
       }
     });
   });
-  server.listen(port);
+  server.listen(port, options.allowExternalAccess ? null : 'localhost');
   return server;
 };
 


### PR DESCRIPTION
This patch forces access to be through 127.0.0.1 unless the --external flag is
used. That way simple use of servedir doesn't expose everything on your machine
to the rest of the network.
